### PR TITLE
Fixing README Docker instructions + tui.py adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The controller now exposes a small REST API for automation or scripting:
 Example usage with `curl`:
 
 ```bash
-BASE_URL="http://ilo-fan-controller-ip.local:3000"
+BASE_URL="http://ilo-fan-controller-ip:3000"
 ```
 
 ### - Unlock manual control
@@ -60,8 +60,8 @@ curl -s "$BASE_URL/api/fans" | jq .
 This resposity contains a docker image which can easily be pulled down to use in a Docker/Kubernetes environment. Modify the comamnd below with **your** values regarding your setup and then you can run the command:
 
 ```bash
-git clone https://github.com/0n1cOn3/ilo4-fan-controller
-docker build -t local/ilo4-fan-controller:latest-local .
+git clone https://github.com/DavidIlie/ilo4-fan-controller
+docker build -t ghcr.io/davidilie/ilo4-fan-controller:latest .
 
 ```bash
 docker run -d \
@@ -71,7 +71,7 @@ docker run -d \
   -e ILO_PASSWORD='*your password**' \
   -e ILO_HOST='*the ip address you access ILO on*' \
   --restart unless-stopped \
-  local/ilo4-fan-controller:latest-local
+  ghcr.io/davidilie/ilo4-fan-controller:latest
 ```
 
 You can modify this to work with Rancher, Portainer, etc.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ This repository contains a docker image which can easily be pulled down to use i
 ```bash
 git clone https://github.com/DavidIlie/ilo4-fan-controller
 docker build -t ghcr.io/davidilie/ilo4-fan-controller:latest .
-
 ```bash
 docker run -d \
   --name=ilo4-fan-controller \

--- a/tui.py
+++ b/tui.py
@@ -7,8 +7,8 @@ import requests
 DEFAULT_BASE_URL = "http://localhost:1234"
 
 # Presets in Percent
-QUIET_PRESET = 20
-NORMAL_PRESET = 35
+QUIET_PRESET = 30 # Slightly increased, as 1U servers (HD controllers) often experience overheating when set to 20%. 
+NORMAL_PRESET = 40
 TURBO_PRESET = 80
 
 


### PR DESCRIPTION
- Restores original links from ghrc registry, removes development paths.
- Removes ".local" since it is not required at all. (Cosmetic)
- tui.py, adjustment for QUIET_PRESET from 20% -> 30% due to known cooling issues with 1U servers (HD-Controller)